### PR TITLE
Add MaximalVerbosity in config check

### DIFF
--- a/src/blockperf/config.py
+++ b/src/blockperf/config.py
@@ -102,7 +102,8 @@ class AppConfig:
         ), "TraceBlockFetchClient not enabled"
         # What are the other possible values? This should allow everything that is above Normal
         assert (
-            self.node_config.get("TracingVerbosity", "") == "NormalVerbosity"
+            self.node_config.get("TracingVerbosity", "")
+            in ("NormalVerbosity", "MaximalVerbosity"),
         ), "TracingVerbosity not enabled"
 
     @property


### PR DESCRIPTION
Added MaximalVerbosity to the config check of the TracingVerbosity setting. 