### PR TITLE
Add prometheus-client to nix propagatedBuildInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
 
               propagatedBuildInputs = [
                 paho-mqtt
+                prometheus-client
                 psutil
                 setuptools
               ];


### PR DESCRIPTION
The CI nix build didn't catch this as it's a runtime only failure.