### PR TITLE
add cardano governor metrics from prometheus endpoint to mqtt payload

### DIFF
--- a/src/blockperf/app.py
+++ b/src/blockperf/app.py
@@ -140,11 +140,11 @@ class App:
         if endpoint := self.app_config.prometheus_endpoint:
             metrics = self.prometheus_metrics(endpoint)
             if metrics:
-                payload["inbound_governor_hot"] = metrics.get(
-                    "cardano_node_metrics_inboundGovernor_hot"
+                payload["inboundGovernor_hot"] = int(
+                    metrics.get("cardano_node_metrics_inboundGovernor_hot")
                 )
-                payload["inbound_governor_warm"] = metrics.get(
-                    "cardano_node_metrics_inboundGovernor_warm"
+                payload["inboundGovernor_warm"] = int(
+                    metrics.get("cardano_node_metrics_inboundGovernor_warm")
                 )
         return payload
 

--- a/src/blockperf/config.py
+++ b/src/blockperf/config.py
@@ -306,3 +306,15 @@ class AppConfig:
                     f"Given address {addr} is not a valid ip address"
                 ) from exc
         return validated_addresses
+
+    @property
+    def prometheus_endpoint(self) -> [str, None]:
+        has_prometheus = self.node_config.get("hasPrometheus")
+        if (
+            not has_prometheus
+            or not isinstance(has_prometheus, list)
+            or not len(has_prometheus) == 2
+            or not isinstance(has_prometheus[1], int)
+        ):
+            return None
+        return f"http://127.0.0.1:{has_prometheus[1]}/metrics"


### PR DESCRIPTION
Adds two new fields to the mqtt payload from the local prometheus endpoint if it is enabled. 