### PR TITLE
Add publishing control and the preview network

### DIFF
--- a/src/blockperf/blocksample.py
+++ b/src/blockperf/blocksample.py
@@ -18,6 +18,8 @@ NETWORK_STARTTIMES = {
     764824073: 1591566291,
     # preprod
     1: 1655683200,
+    # preview
+    2: 1666656000,
 }
 
 

--- a/src/blockperf/mqtt.py
+++ b/src/blockperf/mqtt.py
@@ -34,17 +34,22 @@ class MQTTClient(mqtt.Client):
         client_keyfile: str,
         host: str,
         port: int,
+        publish: bool,
         keepalive: int,
     ) -> None:
         super().__init__(protocol=mqtt.MQTTv5)
-        self.tls_set(
-            ca_certs=ca_certfile,
-            certfile=client_certfile,
-            keyfile=client_keyfile,
-        )
-        logger.info("Connecting to %s:%s", host, port)
-        self.connect(host=host, port=port, keepalive=keepalive)
-        self.loop_start()
+        if publish is True:
+            self.tls_set(
+                ca_certs=ca_certfile,
+                certfile=client_certfile,
+                keyfile=client_keyfile,
+            )
+            logger.info("Connecting to %s:%s", host, port)
+            self.connect(host=host, port=port, keepalive=keepalive)
+            self.loop_start()
+        else:
+            logger.info("Skipping publishing")
+
 
     def on_connect(self, client, userdata, flags, reasonCode, properties):
         logger.info("Connected: %s ", str(reasonCode))


### PR DESCRIPTION
Publishing control:
* Adds a publishing control bool via env var `BLOCKPERF_PUBLISH` which defaults to `True` if unset
* This supports the use case where published metrics to CF don't make sense, such as temp testnet machines, but blockperf metrics would still be valuable to scrape for internal review
* If publishing is disabled, the startup requirements are loosened; for example, cert key declarations are not required.

Network support:
* Adds the preview network